### PR TITLE
Update to v1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.5.1] - 2026-02-19
+- Updated API endpoint from v1.9 to v1.10
+
 ## [0.5.0] - 2026-01-06
 - Added Distance API support:
   - `distance()` - Calculate distances from single origin to multiple destinations

--- a/lib/geocodio/gem.rb
+++ b/lib/geocodio/gem.rb
@@ -15,7 +15,7 @@ module Geocodio
       @api_key = api_key
 
       @conn = Faraday.new(
-        url: 'https://api.geocod.io/v1.9/',
+        url: 'https://api.geocod.io/v1.10/',
         headers: {'Content-Type' => 'application/json' }
       ) do |f|
         f.response :follow_redirects


### PR DESCRIPTION
## Description

> [!NOTE]
> Version 1.10 has not been deployed yet, this PR should not be merged until v1.10 is live

> [!WARNING]
> We will need to regenerate VCR fixtures before this gets merged, this depends on production v1.10 support.

Updates the API version to v1.10.